### PR TITLE
Issue when saving float values.

### DIFF
--- a/src/ProtoBuf.Data/ProtoDataWriter.cs
+++ b/src/ProtoBuf.Data/ProtoDataWriter.cs
@@ -157,7 +157,7 @@ namespace ProtoBuf.Data
                                         break;
 
                                     case ProtoDataType.Float:
-                                        ProtoWriter.WriteFieldHeader(fieldIndex, WireType.Variant, writer);
+                                        ProtoWriter.WriteFieldHeader(fieldIndex, WireType.Fixed32, writer);
                                         ProtoWriter.WriteSingle((float) value, writer);
                                         break;
 


### PR DESCRIPTION
Before this change I got a exception when trying to save a float value.

You can change it to Fixed32 it works like a dream.

If you look in the ProtoWriter.cs Source code it only supports Fixed32 or Fixed64
http://code.google.com/p/protobuf-net/source/browse/trunk/protobuf-net/ProtoWriter.cs?r=423#801
